### PR TITLE
Add more versions to VS build tools

### DIFF
--- a/src/pkgs/vs-buildtools.ps1
+++ b/src/pkgs/vs-buildtools.ps1
@@ -1,52 +1,63 @@
 $global:PwrPackageConfig = @{
-	Name = 'vs-buildtools'
-	Version = '17.142.2'
-	Nonce = $true
+	Name    = 'vs-buildtools'
+	Version = '17.3.2' # see https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-history
+	Nonce   = $true
 }
 
 function global:Install-PwrPackage {
 	$oldPath = $env:Path
 	mkdir '\vs' -Force | Out-Null
-	[Environment]::SetEnvironmentVariable("ProgramFiles(x86)", "\vs", "User")
+	[Environment]::SetEnvironmentVariable('ProgramFiles(x86)', '\vs', 'User')
 	Invoke-WebRequest -UseBasicParsing 'https://aka.ms/vs/17/release/vs_buildtools.exe' -OutFile 'vs_buildtools.exe'
 	cmd /S /C 'start /w vs_buildtools.exe --quiet --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 --remove Microsoft.VisualStudio.Component.Windows81SDK || IF "%ERRORLEVEL%"=="3010" EXIT 0'
 	Write-Output 'Done Installing'
-	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Microsoft Visual Studio" -Path "\pkg\Microsoft Visual Studio"
-	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Windows Kits" -Path "\pkg\Windows Kits"
-	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Microsoft Visual Studio 14.0" -Path "\pkg\Microsoft Visual Studio 14.0"
+	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Microsoft Visual Studio" -Path '\pkg\Microsoft Visual Studio'
+	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Windows Kits" -Path '\pkg\Windows Kits'
+	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Microsoft Visual Studio 14.0" -Path '\pkg\Microsoft Visual Studio 14.0'
 	[System.IO.File]::WriteAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\core\winsdk.bat',
 		[System.IO.File]::ReadAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\core\winsdk.bat').
-			Replace('reg query "%1\Microsoft\Microsoft SDKs\Windows\v10.0" /v "InstallationFolder"', 'echo InstallationFolder X %~dp0..\..\..\..\..\..\..\Windows Kits\10\').
-			Replace('reg query "%1\Microsoft\Microsoft SDKs\Windows\v8.1" /v "InstallationFolder"', 'echo InstallationFolder X %~dp0..\..\..\..\..\..\..\Windows Kits\8.1\').
-			Replace('reg query "%1\Microsoft\Windows Kits\Installed Roots" /v "KitsRoot10"', 'echo KitsRoot10 X %~dp0..\..\..\..\..\..\..\Windows Kits\10\'))
+		Replace('reg query "%1\Microsoft\Microsoft SDKs\Windows\v10.0" /v "InstallationFolder"', 'echo InstallationFolder X %~dp0..\..\..\..\..\..\..\Windows Kits\10\').
+		Replace('reg query "%1\Microsoft\Microsoft SDKs\Windows\v8.1" /v "InstallationFolder"', 'echo InstallationFolder X %~dp0..\..\..\..\..\..\..\Windows Kits\8.1\').
+		Replace('reg query "%1\Microsoft\Windows Kits\Installed Roots" /v "KitsRoot10"', 'echo KitsRoot10 X %~dp0..\..\..\..\..\..\..\Windows Kits\10\'))
 	[System.IO.File]::WriteAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\ext\vcvars\vcvars140.bat',
 		[System.IO.File]::ReadAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\ext\vcvars\vcvars140.bat').
-			Replace('reg query "%1\Microsoft\VisualStudio\SxS\VC7" /v "14.0"', 'echo 14.0 X %~dp0..\..\..\..\..\..\..\..\Microsoft Visual Studio 14.0\VC\'))
+		Replace('reg query "%1\Microsoft\VisualStudio\SxS\VC7" /v "14.0"', 'echo 14.0 X %~dp0..\..\..\..\..\..\..\..\Microsoft Visual Studio 14.0\VC\'))
 	Write-Output 'Done Hacking'
-	$vars = 'WindowsSdkVerBinPath', 'VCToolsRedistDir', 'VSCMD_ARG_VCVARS_VER', 'UniversalCRTSdkDir', 'WindowsSdkDir', 'VCIDEInstallDir', 'VSCMD_ARG_HOST_ARCH', 'VCToolsVersion', 'INCLUDE', 'WindowsLibPath', 'VCToolsInstallDir', 'VCINSTALLDIR', 'VS170COMNTOOLS', 'LIBPATH', 'path', 'UCRTVersion', 'DevEnvDir', 'WindowsSDKLibVersion', 'LIB', 'VSCMD_VER', 'VSINSTALLDIR', 'VSCMD_ARG_TGT_ARCH'
-	foreach ($v in $vars) {
-		Clear-Item "env:$v" -Force -ErrorAction SilentlyContinue
+	$PwrPackageVars = @{}
+	foreach ($config in @(@{Name = 'default'}, @{Name = 'msvc-140'; Ver = '14.0'}, @{Name = 'msvc-141'; Ver = '14.16'}, @{Name = 'msvc-142'; Ver = '14.29'})) {
+		Write-Output "Evaluating variables for configuration $($config.name)"
+		$vars = 'WindowsSdkVerBinPath', 'VCToolsRedistDir', 'VSCMD_ARG_VCVARS_VER', 'UniversalCRTSdkDir', 'WindowsSdkDir', 'VCIDEInstallDir', 'VSCMD_ARG_HOST_ARCH', 'VCToolsVersion', 'INCLUDE', 'WindowsLibPath', 'VCToolsInstallDir', 'VCINSTALLDIR', 'VS170COMNTOOLS', 'LIBPATH', 'path', 'UCRTVersion', 'DevEnvDir', 'WindowsSDKLibVersion', 'LIB', 'VSCMD_VER', 'VSINSTALLDIR', 'VSCMD_ARG_TGT_ARCH'
+		foreach ($v in $vars) {
+			Clear-Item "env:$v" -Force -ErrorAction SilentlyContinue
+		}
+		Write-Output 'Env Cleared'
+		$path = 'C:\windows;C:\windows\system32;C:\windows\system32\WindowsPowerShell\v1.0'
+		$env:path = $path
+		$vsSetup = "`"$((Get-ChildItem -Path '\pkg' -Recurse -Include 'VsDevCmd.bat' | Select-Object -First 1).FullName)`" $(if ($config.name -ne 'default') { "-vcvars_ver=$($config.ver)" }) -arch=x64 -host_arch=x64"
+		Write-Output 'Starting Dev Setup'
+		$vsenv = cmd /S /C "$vsSetup && set"
+		Write-Output $vsenv
+		$vsenv.Split([Environment]::NewLine, [StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object { $s = $_.Split('='); if ($s.count -eq 2) { Set-Item "env:$($s[0])" $s[1] } }
+		$map = @{}
+		foreach ($var in $vars) {
+			$map.$var = (Get-Item "env:$var" -ErrorAction SilentlyContinue).value
+		}
+		$map.path = $map.path.Replace($path, '')
+		if ($config.name -eq 'default') {
+			$PwrPackageVars.env = $map
+		} else {
+			$PwrPackageVars."$($config.name)" = @{env = $map}
+		}
 	}
-	Write-Output 'Env Cleared'
-	$path = "C:\windows;C:\windows\system32;C:\windows\system32\WindowsPowerShell\v1.0"
-	$env:path = $path
-	$vsSetup = "`"$((Get-ChildItem -Path '\pkg' -Recurse -Include 'VsDevCmd.bat' | Select-Object -First 1).FullName)`" -arch=x64 -host_arch=x64"
-	Write-Output 'Starting Dev Setup'
-	$vsenv = cmd /S /C "$vsSetup && set"
-	Write-Output $vsenv
-	$vsenv.Split([Environment]::NewLine, [StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object { $s = $_.Split("="); if ($s.count -eq 2) { Set-Item "env:$($s[0])" $s[1] } }
-	$map = @{}
-	foreach ($var in $vars) {
-		$map.$var = (get-item "env:$var" -ErrorAction SilentlyContinue).value
-	}
-	$map.path = $map.path.Replace($path, '')
-	Write-PackageVars @{ env = $map }
+	Write-PackageVars $PwrPackageVars
 	$env:path = $oldPath
 }
 
 function global:Test-PwrPackageInstall {
-	pwr sh 'file:///\pkg'
-	cl
-	& $env:ComSpec /c 'VsDevCmd -vcvars_ver=14.0 -arch=x64 -host_arch=x64 && cl'
-	pwr exit
+	foreach ($config in @('default', 'msvc-140', 'msvc-141', 'msvc-142')) {
+		Write-Host "Testing config $config"
+		pwr sh "file:///\pkg < $config"
+		cl
+		pwr exit
+	}
 }

--- a/src/pkgs/vs-buildtools.ps1
+++ b/src/pkgs/vs-buildtools.ps1
@@ -1,24 +1,28 @@
 $global:PwrPackageConfig = @{
 	Name = 'vs-buildtools'
-	Version = '17.142.1'
+	Version = '17.142.2'
 	Nonce = $true
 }
 
 function global:Install-PwrPackage {
+	$oldPath = $env:Path
 	mkdir '\vs' -Force | Out-Null
 	[Environment]::SetEnvironmentVariable("ProgramFiles(x86)", "\vs", "User")
 	Invoke-WebRequest -UseBasicParsing 'https://aka.ms/vs/17/release/vs_buildtools.exe' -OutFile 'vs_buildtools.exe'
-	cmd /S /C 'start /w vs_buildtools.exe --quiet --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 --remove Microsoft.VisualStudio.Component.Windows81SDK || IF "%ERRORLEVEL%"=="3010" EXIT 0'
+	cmd /S /C 'start /w vs_buildtools.exe --quiet --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 --remove Microsoft.VisualStudio.Component.Windows81SDK || IF "%ERRORLEVEL%"=="3010" EXIT 0'
 	Write-Output 'Done Installing'
-	robocopy /MIR /MT:32 "${env:ProgramFiles(x86)}\Microsoft Visual Studio" "\pkg\Microsoft Visual Studio" | Out-Null
-	robocopy /MIR /MT:32 "${env:ProgramFiles(x86)}\Windows Kits" "\pkg\Windows Kits" | Out-Null
-	Write-Output 'Done Copying'
-	$winSdk = '\pkg\Windows Kits\10\'
-	Set-RegistryKey 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0' 'InstallationFolder' $winSdk
-	Set-RegistryKey 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows Kits\Installed Roots' 'KitsRoot10' $winSdk
-	Remove-Item (Get-ChildItem -Path '\pkg' -Recurse -Include 'netfxsdk.bat' | Select-Object -First 1).FullName -Force
-	Remove-Item (Get-ChildItem -Path '\pkg' -Recurse -Include 'dotnet.bat' | Select-Object -First 1).FullName -Force
-	Write-Output 'Registry Saved'
+	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Microsoft Visual Studio" -Path "\pkg\Microsoft Visual Studio"
+	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Windows Kits" -Path "\pkg\Windows Kits"
+	New-Item -Type Junction -Target "${env:ProgramFiles(x86)}\Microsoft Visual Studio 14.0" -Path "\pkg\Microsoft Visual Studio 14.0"
+	[System.IO.File]::WriteAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\core\winsdk.bat',
+		[System.IO.File]::ReadAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\core\winsdk.bat').
+			Replace('reg query "%1\Microsoft\Microsoft SDKs\Windows\v10.0" /v "InstallationFolder"', 'echo InstallationFolder X %~dp0..\..\..\..\..\..\..\Windows Kits\10\').
+			Replace('reg query "%1\Microsoft\Microsoft SDKs\Windows\v8.1" /v "InstallationFolder"', 'echo InstallationFolder X %~dp0..\..\..\..\..\..\..\Windows Kits\8.1\').
+			Replace('reg query "%1\Microsoft\Windows Kits\Installed Roots" /v "KitsRoot10"', 'echo KitsRoot10 X %~dp0..\..\..\..\..\..\..\Windows Kits\10\'))
+	[System.IO.File]::WriteAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\ext\vcvars\vcvars140.bat',
+		[System.IO.File]::ReadAllText('\pkg\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\vsdevcmd\ext\vcvars\vcvars140.bat').
+			Replace('reg query "%1\Microsoft\VisualStudio\SxS\VC7" /v "14.0"', 'echo 14.0 X %~dp0..\..\..\..\..\..\..\..\Microsoft Visual Studio 14.0\VC\'))
+	Write-Output 'Done Hacking'
 	$vars = 'WindowsSdkVerBinPath', 'VCToolsRedistDir', 'VSCMD_ARG_VCVARS_VER', 'UniversalCRTSdkDir', 'WindowsSdkDir', 'VCIDEInstallDir', 'VSCMD_ARG_HOST_ARCH', 'VCToolsVersion', 'INCLUDE', 'WindowsLibPath', 'VCToolsInstallDir', 'VCINSTALLDIR', 'VS170COMNTOOLS', 'LIBPATH', 'path', 'UCRTVersion', 'DevEnvDir', 'WindowsSDKLibVersion', 'LIB', 'VSCMD_VER', 'VSINSTALLDIR', 'VSCMD_ARG_TGT_ARCH'
 	foreach ($v in $vars) {
 		Clear-Item "env:$v" -Force -ErrorAction SilentlyContinue
@@ -26,7 +30,7 @@ function global:Install-PwrPackage {
 	Write-Output 'Env Cleared'
 	$path = "C:\windows;C:\windows\system32;C:\windows\system32\WindowsPowerShell\v1.0"
 	$env:path = $path
-	$vsSetup = "`"$((Get-ChildItem -Path '\pkg' -Recurse -Include 'VsDevCmd.bat' | Select-Object -First 1).FullName)`" -vcvars_ver=14.29 -arch=x64 -host_arch=x64"
+	$vsSetup = "`"$((Get-ChildItem -Path '\pkg' -Recurse -Include 'VsDevCmd.bat' | Select-Object -First 1).FullName)`" -arch=x64 -host_arch=x64"
 	Write-Output 'Starting Dev Setup'
 	$vsenv = cmd /S /C "$vsSetup && set"
 	Write-Output $vsenv
@@ -37,8 +41,12 @@ function global:Install-PwrPackage {
 	}
 	$map.path = $map.path.Replace($path, '')
 	Write-PackageVars @{ env = $map }
+	$env:path = $oldPath
 }
 
 function global:Test-PwrPackageInstall {
-	Get-Content '\pkg\.pwr'
+	pwr sh 'file:///\pkg'
+	cl
+	& $env:ComSpec /c 'VsDevCmd -vcvars_ver=14.0 -arch=x64 -host_arch=x64 && cl'
+	pwr exit
 }


### PR DESCRIPTION
This switches the default build tools from VS 2019 to VS 2022 and also adds support to allow switching to VS 2017 and VS 2015 build tools.