### PR TITLE
Fix vs-buildtools remove path

### DIFF
--- a/src/pkgs/vs-buildtools.ps1
+++ b/src/pkgs/vs-buildtools.ps1
@@ -90,7 +90,7 @@ function global:Install-PwrPackage {
 			$PwrPackageVars."$($msvc.name)-$arch" = @{env = $map}
 		}
 	}
-	Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits" '10.0.*' -Recurse -Exclude $PwrPackageVars.env.UCRTVersion | Remove-Item -Recurse -Force
+	Get-ChildItem '\pkg\Windows Kits' '10.0.*' -Recurse -Exclude $PwrPackageVars.env.UCRTVersion | Remove-Item -Recurse -Force
 	Write-PackageVars $PwrPackageVars
 	$env:path = $oldPath
 }


### PR DESCRIPTION
I promise I didn't mess this up originally... Ok, maybe I did.

This reduces the generated docker image from around 20GB to about 13GB.