### PR TITLE
Make Java path consistent

### DIFF
--- a/src/pkgs/jdk11.ps1
+++ b/src/pkgs/jdk11.ps1
@@ -19,23 +19,28 @@ function global:Install-PwrPackage {
 	$Params = @{
 		AssetName = $Asset.Name
 		AssetURL = $Asset.URL
+		ToolDir = '\pkg-preinstall\x64'
 	}
 	Install-BuildTool @Params
+	New-Item -Path '\pkg\x64' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x64' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x64'
 	$Params_x86 = @{
 		AssetName = $Asset.Name.Replace('_x64_', '_x86-32_')
 		AssetURL = $Asset.URL.Replace('_x64_', '_x86-32_')
-		ToolDir = '\pkg\x86'
+		ToolDir = '\pkg-preinstall\x86'
 	}
 	Install-BuildTool @Params_x86
+	New-Item -Path '\pkg\x86' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x86' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x86'
 	Write-PackageVars @{
 		env = @{
-			java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-			path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+			java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+			path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 		}
 		amd64 = @{
 			env = @{
-				java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-				path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+				java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+				path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 			}
 		}
 		x86 = @{

--- a/src/pkgs/jdk17.ps1
+++ b/src/pkgs/jdk17.ps1
@@ -19,23 +19,28 @@ function global:Install-PwrPackage {
 	$Params = @{
 		AssetName = $Asset.Name
 		AssetURL = $Asset.URL
+		ToolDir = '\pkg-preinstall\x64'
 	}
 	Install-BuildTool @Params
+	New-Item -Path '\pkg\x64' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x64' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x64'
 	$Params_x86 = @{
 		AssetName = $Asset.Name.Replace('_x64_', '_x86-32_')
 		AssetURL = $Asset.URL.Replace('_x64_', '_x86-32_')
-		ToolDir = '\pkg\x86'
+		ToolDir = '\pkg-preinstall\x86'
 	}
 	Install-BuildTool @Params_x86
+	New-Item -Path '\pkg\x86' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x86' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x86'
 	Write-PackageVars @{
 		env = @{
-			java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-			path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+			java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+			path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 		}
 		amd64 = @{
 			env = @{
-				java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-				path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+				java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+				path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 			}
 		}
 		x86 = @{

--- a/src/pkgs/jdk8.ps1
+++ b/src/pkgs/jdk8.ps1
@@ -19,23 +19,28 @@ function global:Install-PwrPackage {
 	$Params = @{
 		AssetName = $Asset.Name
 		AssetURL = $Asset.URL
+		ToolDir = '\pkg-preinstall\x64'
 	}
 	Install-BuildTool @Params
+	New-Item -Path '\pkg\x64' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x64' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x64'
 	$Params_x86 = @{
 		AssetName = $Asset.Name.Replace('_x64_', '_x86-32_')
 		AssetURL = $Asset.URL.Replace('_x64_', '_x86-32_')
-		ToolDir = '\pkg\x86'
+		ToolDir = '\pkg-preinstall\x86'
 	}
 	Install-BuildTool @Params_x86
+	New-Item -Path '\pkg\x86' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x86' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x86'
 	Write-PackageVars @{
 		env = @{
-			java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-			path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+			java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+			path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 		}
 		amd64 = @{
 			env = @{
-				java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-				path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+				java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+				path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 			}
 		}
 		x86 = @{

--- a/src/pkgs/jre11.ps1
+++ b/src/pkgs/jre11.ps1
@@ -19,23 +19,28 @@ function global:Install-PwrPackage {
 	$Params = @{
 		AssetName = $Asset.Name
 		AssetURL = $Asset.URL
+		ToolDir = '\pkg-preinstall\x64'
 	}
 	Install-BuildTool @Params
+	New-Item -Path '\pkg\x64' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x64' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x64'
 	$Params_x86 = @{
 		AssetName = $Asset.Name.Replace('_x64_', '_x86-32_')
 		AssetURL = $Asset.URL.Replace('_x64_', '_x86-32_')
-		ToolDir = '\pkg\x86'
+		ToolDir = '\pkg-preinstall\x86'
 	}
 	Install-BuildTool @Params_x86
+	New-Item -Path '\pkg\x86' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x86' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x86'
 	Write-PackageVars @{
 		env = @{
-			java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-			path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+			java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+			path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 		}
 		amd64 = @{
 			env = @{
-				java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-				path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+				java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+				path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 			}
 		}
 		x86 = @{

--- a/src/pkgs/jre17.ps1
+++ b/src/pkgs/jre17.ps1
@@ -19,23 +19,28 @@ function global:Install-PwrPackage {
 	$Params = @{
 		AssetName = $Asset.Name
 		AssetURL = $Asset.URL
+		ToolDir = '\pkg-preinstall\x64'
 	}
 	Install-BuildTool @Params
+	New-Item -Path '\pkg\x64' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x64' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x64'
 	$Params_x86 = @{
 		AssetName = $Asset.Name.Replace('_x64_', '_x86-32_')
 		AssetURL = $Asset.URL.Replace('_x64_', '_x86-32_')
-		ToolDir = '\pkg\x86'
+		ToolDir = '\pkg-preinstall\x86'
 	}
 	Install-BuildTool @Params_x86
+	New-Item -Path '\pkg\x86' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x86' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x86'
 	Write-PackageVars @{
 		env = @{
-			java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-			path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+			java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+			path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 		}
 		amd64 = @{
 			env = @{
-				java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-				path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+				java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+				path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 			}
 		}
 		x86 = @{

--- a/src/pkgs/jre8.ps1
+++ b/src/pkgs/jre8.ps1
@@ -19,23 +19,28 @@ function global:Install-PwrPackage {
 	$Params = @{
 		AssetName = $Asset.Name
 		AssetURL = $Asset.URL
+		ToolDir = '\pkg-preinstall\x64'
 	}
 	Install-BuildTool @Params
+	New-Item -Path '\pkg\x64' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x64' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x64'
 	$Params_x86 = @{
 		AssetName = $Asset.Name.Replace('_x64_', '_x86-32_')
 		AssetURL = $Asset.URL.Replace('_x64_', '_x86-32_')
-		ToolDir = '\pkg\x86'
+		ToolDir = '\pkg-preinstall\x86'
 	}
 	Install-BuildTool @Params_x86
+	New-Item -Path '\pkg\x86' -ItemType Directory -Force -ErrorAction Ignore | Out-Null
+	Move-Item "$(Get-ChildItem -Path '\pkg-preinstall\x86' -Recurse -Include 'bin' | ForEach-Object { Split-Path $_ })\*" '\pkg\x86'
 	Write-PackageVars @{
 		env = @{
-			java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-			path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+			java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+			path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 		}
 		amd64 = @{
 			env = @{
-				java_home = (Split-Path (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
-				path = (Get-ChildItem -Path '\pkg' -Exclude 'x86' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
+				java_home = (Split-Path (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'bin' | Select-Object -First 1).FullName -Parent)
+				path = (Get-ChildItem -Path '\pkg\x64' -Recurse -Include 'java.exe' | Select-Object -First 1).DirectoryName
 			}
 		}
 		x86 = @{


### PR DESCRIPTION
This PR makes the path consistent for all releases of Java. This allows settings such as those in vscode to use `path\to\airpower\ref\jdk\x64` instead of `path\to\airpower\ref\jdk\jdk-17.0.5+8`.