### PR TITLE
Remove git system credential helper default pop-up

### DIFF
--- a/src/pkgs/git.ps1
+++ b/src/pkgs/git.ps1
@@ -20,6 +20,7 @@ function global:Install-PwrPackage {
 	Invoke-WebRequest -UseBasicParsing 'https://www.7-zip.org/a/7za920.zip' -OutFile "$env:temp\7z.zip"
 	Expand-Archive "$env:temp\7z.zip" "$env:temp\7z"
 	& "$env:temp\7z\7za.exe" x -o'\pkg' $git | Out-Null
+	& (Get-ChildItem -Path '\pkg' -Recurse -Include 'git.exe' | Select-Object -First 1) config --system --unset credential.helper
 	Write-PackageVars @{
 		env = @{
 			path = (@(


### PR DESCRIPTION
This PR removes the default git system credential helper, so the initial credential helper pop-up after every update won't happen. (It prompts for username and password on the command line by default, if no other config setting is specified.)

Ideally, the user would set this in the user config, and every time an update happens, git would use the setting in the user config instead of the system config. However, it always reverts to the system config, even if it is defined in the user config. For example, I have the following in my `~/.gitconfig`:

```
[credential]
	helper = !\"C:/Users/Me/AppData/Local/Airpower/ref/git/mingw64/libexec/git-core/git-credential-wincred.exe\"
[credential "helperselector"]
	selected = wincred
```

And I still get prompted every time I update git. (If there is a way to have the user config override the system config, that may be prefered to using this solution.)