### PR TITLE
Allow building specific versions of VS BuildTools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,14 +55,14 @@ jobs:
         Invoke-PwrPackageScan
 
     - name: Login to DockerHub
-      if: ${{ github.ref == 'refs/heads/main' && steps.pkg.outputs.up-to-date == 'False'}}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/main/')) && steps.pkg.outputs.up-to-date == 'False'}}
       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and push container
-      if: ${{ github.ref == 'refs/heads/main' && steps.pkg.outputs.up-to-date == 'False'}}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/main/')) && steps.pkg.outputs.up-to-date == 'False'}}
       run: |
         . .\src\main.ps1
         & '${{ matrix.package }}'

--- a/src/main.ps1
+++ b/src/main.ps1
@@ -78,7 +78,7 @@ function Save-WorkflowMatrix {
 		Clear-PwrPackageScript
 		& $script.FullName
 		Test-PwrPackageScript
-		if ("${env:GITHUB_REF_NAME}.ps1" -eq $script.Name -or $env:GITHUB_REF_NAME.StartsWith("$($script.BaseName)-")) {
+		if ("$($env:GITHUB_REF_NAME -replace '^.*/').ps1" -eq $script.Name -or ($env:GITHUB_REF_NAME -replace '^.*/').StartsWith("$($script.BaseName)-")) {
 			$pkgs = ,$script.FullName.Replace((Get-Location), '.')
 			break
 		} elseif ((-not $PwrPackageConfig.Nonce) -or ("$($PwrPackageConfig.Name)-$($PwrPackageConfig.Version)" -notin $tagList.tags)) {


### PR DESCRIPTION
This PR allows pushing to branches with version numbers to build specific versions (e.g., pushing to `vs-buildtools-17.4.8` would build version `17.4.8` of `vs-buildtools`). (Other packages could support this, if needed.)

Also, pushing to the branch `main/[package]` triggers a "main" build (build and docker upload) of just that package. This allows one-off builds of individual packages (and versions for VS build tools).

If this is approved, I'm requesting a one-off build be created for `vs-buildtools:17.4.8`, by pushing to the branch `main/vs-buildtools-17.4.8`.