### PR TITLE
Allow cmake-converter install behind corporate firewall

### DIFF
--- a/src/pkgs/cmake-converter.ps1
+++ b/src/pkgs/cmake-converter.ps1
@@ -8,7 +8,7 @@ function global:Install-PwrPackage {
 	Set-Content $BatFile @"
 	@echo off
 
-	python -c "import cmake_converter" 2> NUL || python -m pip install cmake_converter --quiet --exists-action i
+	python -c "import cmake_converter" 2> NUL || python -m pip install --trusted-host pypi.org cmake_converter --quiet --exists-action i
 	python -m cmake_converter.main %*
 "@
 


### PR DESCRIPTION
This PR allows the `pip install` to succeed without the following error:
```
Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)')))
```