### PR TITLE
Use actions/checkout@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix: ${{ steps.init.outputs.matrix }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Analyze packages
       id: init
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Run ${{ matrix.package }}
       id: pkg

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -28,7 +28,7 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@2044ae068e37d0161fa2127de04c19633882f061

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 - Copyright 2021 Troy Southard <troy.southard@us.af.mil>
 - Copyright 2022 Nick Little <nicklaus.little@gmail.com>
 - Copyright 2023 Thomas Bateson <thomas.bateson@eagles.oc.edu>
+- Copyright 2024 Levi Golston <levi.golston@us.af.mil>
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
 
 ## Note for U.S. Federal Employees


### PR DESCRIPTION
Bumps the checkout action version (avoids repeated warnings about using a deprecated Node.js version).