### PR TITLE
Add gradle 9

### DIFF
--- a/src/pkgs/gradle/gradle9.ps1
+++ b/src/pkgs/gradle/gradle9.ps1
@@ -1,13 +1,13 @@
 $global:PwrPackageConfig = @{
 	Name = 'gradle'
-	Matcher = '^gradle-6\.'
+	Matcher = '^gradle-9\.'
 }
 
 function global:Install-PwrPackage {
 	$Params = @{
 		Owner = 'gradle'
 		Repo = 'gradle'
-		TagPattern = '^v(6)\.([0-9]+)\.([0-9]+)$'
+		TagPattern = '^v(9)\.([0-9]+)\.([0-9]+)$'
 	}
 	$Latest = Get-GitHubTag @Params
 	$PwrPackageConfig.UpToDate = -not $Latest.Version.LaterThan($PwrPackageConfig.Latest)


### PR DESCRIPTION
- Add support for gradle 9
- Remove gradle 6 support, as it appears to no longer be supported (last update was Feb 2023)
  - Version 7 and 8 have both been updated recently so they can remain for now