### PR TITLE
Fix dotnet-sdk

### DIFF
--- a/src/pkgs/dotnet-sdk.ps1
+++ b/src/pkgs/dotnet-sdk.ps1
@@ -6,7 +6,7 @@ function global:Install-PwrPackage {
 	$Params = @{
 		Owner = 'dotnet'
 		Repo = 'sdk'
-		TagPattern = '^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-rtm.*)$'
+		TagPattern = '^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-rtm.*)?$'
 	}
 	$Latest = Get-GitHubTag @Params
 	$PwrPackageConfig.UpToDate = -not $Latest.Version.LaterThan($PwrPackageConfig.Latest)


### PR DESCRIPTION
Closes #100. Makes -rtm tag optional as it has not been used in recent versions.