### PR TITLE
Update PSScriptAnalyzer action

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run PSScriptAnalyzer
-        uses: microsoft/psscriptanalyzer-action@2044ae068e37d0161fa2127de04c19633882f061
+        uses: microsoft/psscriptanalyzer-action@v1.1
         with:
           # Check https://github.com/microsoft/action-psscriptanalyzer for more info about the options.
           # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
@@ -43,6 +43,6 @@ jobs:
       
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
The PSScriptAnalyzer job gives this output currently:
`"WARNING: The version '1.24.0' of module 'PSScriptAnalyzer' is currently in use. Retry the operation after closing the applications."`. This bumps to a newer psscriptanalyzer-action version to hopefully fix the issue.
