### PR TITLE
Update vs-buildtools

### DIFF
--- a/src/pkgs/vs-buildtools.ps1
+++ b/src/pkgs/vs-buildtools.ps1
@@ -16,7 +16,7 @@ function global:Install-PwrPackage {
 	$VersionWanted = if ($env:GITHUB_REF_NAME -match '-([0-9]+\.[0-9]+\.[0-9]+)$') { [SemanticVersion]::new($Matches[1]) } else { $null }
 	# See https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history
 	(Invoke-WebRequest 'https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history').Content -split '</tr>' | ForEach-Object {
-		if ($_ -match '(?s)<tr\b.+\bLTSC\b.+>([0-9]+\.[0-9]+\.[0-9]+)</.+ href="([^"]+/vs_BuildTools\.exe)"') {
+		if ($_ -match '(?s)<tr\b.+\b(?:Current|LTSC|Stable)\b.+>([0-9]+\.[0-9]+\.[0-9]+)(?:\s+[^<]*)</.+ href="([^"]+/vs_BuildTools\.exe)"') {
 			$NewVersion = [SemanticVersion]::new($Matches[1])
 			if (($null -ne $VersionWanted -and $VersionWanted.CompareTo($NewVersion) -eq 0) -or
 					($null -eq $VersionWanted -and $NewVersion -notin $PwrPackageConfig.Tags -and (-not $VSInfo -or $NewVersion.LaterThan($VSInfo.Version)))) {


### PR DESCRIPTION
Adds support for the 17.14.X series of releases. (MS changed their versioning so these are not LTSC releases. Although, 17.14 is suspiciously supported until 2032.)

Will eventually need to add support for the 18.X releases. I may wait until they have LTSC releases.